### PR TITLE
Remove searching for *.yaml files

### DIFF
--- a/ubuntu/debian/libgz-fuel-tools10.install
+++ b/ubuntu/debian/libgz-fuel-tools10.install
@@ -1,4 +1,3 @@
 usr/lib/*/*.so.*
 usr/lib/*/*/*.rb
-usr/share/gz/*/*.yaml
 usr/share/gz/*.completion*/*


### PR DESCRIPTION
### CONTEXT
Introducing this PR: https://github.com/gazebosim/gz-fuel-tools/pull/423

Made our debbuilders start to fail on jammy and noble, see:
https://build.osrfoundation.org/job/gz-fuel-tools10-debbuilder/365/ (jammy)
https://build.osrfoundation.org/job/gz-fuel-tools10-debbuilder/364/ (noble)

The error is: 

```
dh_install: warning: Cannot find (any matches for) "usr/share/gz/*/*.yaml" (tried in ., debian/tmp)

dh_install: warning: libgz-fuel-tools10 missing files: usr/share/gz/*/*.yaml
dh_install: error: missing files, aborting
make: *** [debian/rules:5: binary] Error 25
```

### Solution 

With this PR, the line searching for yaml files will be removed. This was needed earlier because there was a conf.yaml file that was removed starting on fuel_tools9, I think it's not needed anymore. Happy to iterate if my assumption is wrong.