### PR TITLE
Fix fuel-tools path in d/rules

### DIFF
--- a/ubuntu/debian/rules
+++ b/ubuntu/debian/rules
@@ -18,5 +18,5 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	dh_auto_install
-	install -d debian/tmp/usr/share/gz/gz-fuel-tools10/
-	install ./obj-*/*.tag.xml debian/tmp/usr/share/gz/gz-fuel-tools10/
+	install -d debian/tmp/usr/share/gz/gz-fuel_tools10/
+	install ./obj-*/*.tag.xml debian/tmp/usr/share/gz/gz-fuel_tools10/


### PR DESCRIPTION
Tested https://build.osrfoundation.org/view/gz-ionic/job/gz-fuel-tools10-debbuilder/472/